### PR TITLE
Fixing a bug with the choice. 

### DIFF
--- a/src/components/code/SpecCode.vue
+++ b/src/components/code/SpecCode.vue
@@ -241,7 +241,7 @@ export default {
           input = selectedTransition
           output = this.selectedAction
         }
-        
+
         if (this.transitionSettings.type === 'comm') {
           this.sendActionSelection(
             {
@@ -425,9 +425,5 @@ export default {
 
   pre {
     margin: 0;
-  }
-
-  code {
-    min-height: 20em;
   }
 </style>

--- a/src/components/code/SpecCode.vue
+++ b/src/components/code/SpecCode.vue
@@ -232,34 +232,34 @@ export default {
             position: this.selectedAction.position,
             choose_left: selectedTransition.position.tag === 'left'
           })
-      }
-
-      let input, output
-      if (this.selectedAction.type === 'input') {
-        input = this.selectedAction
-        output = selectedTransition
       } else {
-        input = selectedTransition
-        output = this.selectedAction
-      }
+        let input, output
+        if (this.selectedAction.type === 'input') {
+          input = this.selectedAction
+          output = selectedTransition
+        } else {
+          input = selectedTransition
+          output = this.selectedAction
+        }
 
-      if (this.transitionSettings.type === 'comm') {
-        this.sendActionSelection(
-          {
-            type: 'comm',
-            input_position: input.position,
-            output_position: output.position
-          })
-      } else if (this.transitionSettings.type === 'eavesdrop') {
-        this.sendActionSelection(
-          {
-            type: 'eavesdrop',
-            input_position: input.position,
-            output_position: output.position,
-            channel: this.selectedAction.channel
-          })
-      } else {
-        logger.error(`Invalid transition selection type ${this.transitionSettings.type}`)
+        if (this.transitionSettings.type === 'comm') {
+          this.sendActionSelection(
+            {
+              type: 'comm',
+              input_position: input.position,
+              output_position: output.position
+            })
+        } else if (this.transitionSettings.type === 'eavesdrop') {
+          this.sendActionSelection(
+            {
+              type: 'eavesdrop',
+              input_position: input.position,
+              output_position: output.position,
+              channel: this.selectedAction.channel
+            })
+        } else {
+          logger.error(`Invalid transition selection type ${this.transitionSettings.type}`)
+        }
       }
     },
     /**
@@ -425,5 +425,9 @@ export default {
 
   pre {
     margin: 0;
+  }
+
+  code {
+    min-height: 20em;
   }
 </style>

--- a/src/util/prism-deepsec.js
+++ b/src/util/prism-deepsec.js
@@ -2,11 +2,11 @@ import Prism from 'prismjs'
 
 let filters = {
   position: {
-    pattern: /%(\d+(-\d+)*(-\w+)?)%[^%]+%\/\1%/, // Something like "%142%...%/142%" or "%752-1-2%...%/752-1-2%"
+    pattern: /%(\d+(-\d+)*(-\w+)?)%[\s\S]*?%\/\1%/, // Something like "%142%...%/142%" or "%752-1-2%...%/752-1-2%"
     inside: {
       // Used to avoid infinite loop, see https://github.com/PrismJS/prism/issues/2133
       'position-content': {
-        pattern: /(?<=%(\d+(-\d+)*(-\w+)?)%)[^%]+(?=%\/\1%)/
+        pattern: /(?<=%(\d+(-\d+)*(-\w+)?)%)[\s\S]*?(?=%\/\1%)/
         // Set inside later
       }
     }
@@ -53,7 +53,7 @@ Prism.hooks.add('wrap', env => {
   else if (env.type === 'position') {
     const index = env.content.match(/^%([-\d]+(?:\w+)?)%/)[1]
     env.classes.push(`position-${index}`)
-    env.content = env.content.match(/^%[-\d]+(?:\w+)?%([^%]+)%\/[-\d]+(?:\w+)?%$/)[1]
+    env.content = env.content.match(/^%[-\d]+(?:\w+)?%([\s\S]*?)%\/[-\d]+(?:\w+)?%$/)[1]
   }
   // Format projection function
   else if (env.type === 'function' && env.content.startsWith('proj_{')) {

--- a/src/util/prism-deepsec.js
+++ b/src/util/prism-deepsec.js
@@ -2,11 +2,11 @@ import Prism from 'prismjs'
 
 let filters = {
   position: {
-    pattern: /%(\d+(-\d+)*(-\w+)?)%[\s\S]*?%\/\1%/, // Something like "%142%...%/142%" or "%752-1-2%...%/752-1-2%"
+    pattern: /%(\d+(-\d+)*(-\w+)?)%(.|\n)+?%\/\1%/, // Something like "%142%...%/142%" or "%752-1-2%...%/752-1-2%"
     inside: {
       // Used to avoid infinite loop, see https://github.com/PrismJS/prism/issues/2133
       'position-content': {
-        pattern: /(?<=%(\d+(-\d+)*(-\w+)?)%)[\s\S]*?(?=%\/\1%)/
+        pattern: /(?<=%(\d+(-\d+)*(-\w+)?)%)(.|\n)+?(?=%\/\1%)/
         // Set inside later
       }
     }
@@ -53,7 +53,7 @@ Prism.hooks.add('wrap', env => {
   else if (env.type === 'position') {
     const index = env.content.match(/^%([-\d]+(?:\w+)?)%/)[1]
     env.classes.push(`position-${index}`)
-    env.content = env.content.match(/^%[-\d]+(?:\w+)?%([\s\S]*?)%\/[-\d]+(?:\w+)?%$/)[1]
+    env.content = env.content.match(/^%[-\d]+(?:\w+)?%((.|\n)+?)%\/[-\d]+(?:\w+)?%$/)[1]
   }
   // Format projection function
   else if (env.type === 'function' && env.content.startsWith('proj_{')) {


### PR DESCRIPTION
I had a bug with the following file

```
free c.
free c1,c2,ok,ko,ok1,ko1.
          
fun h/2.

let P =
(  out(c,ok); out(c,ok)) + (new k; out(c,ko); out(c,ko) + new k'; out(c,ko); out(c,ok)).

let Q =
(  out(c,ok)  + (new k; out(c,ko)  + new k'; out(c,ko))).


query trace_equiv(P,Q).

(* Should not be equivalent *)
```

It was displaying the positions with %XX-left% and so on. I had to change the regex of prism for it to work. It seemed to work before on Linux so was it an incompatibility with OSX ? Need to check that it works on Linux.